### PR TITLE
initial puller and mounter

### DIFF
--- a/builder/rootfs.go
+++ b/builder/rootfs.go
@@ -4,11 +4,6 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/AkihiroSuda/filegrain/cp"
-	"github.com/AkihiroSuda/filegrain/image"
-	"github.com/AkihiroSuda/filegrain/image/imageutil"
-	"github.com/AkihiroSuda/filegrain/version"
-
 	"github.com/Sirupsen/logrus"
 	progressbar "github.com/cheggaaa/pb"
 	"github.com/golang/protobuf/proto"
@@ -17,6 +12,12 @@ import (
 	spec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stevvooe/continuity"
 	pb "github.com/stevvooe/continuity/proto"
+
+	"github.com/AkihiroSuda/filegrain/continuityutil"
+	"github.com/AkihiroSuda/filegrain/cp"
+	"github.com/AkihiroSuda/filegrain/image"
+	"github.com/AkihiroSuda/filegrain/image/imageutil"
+	"github.com/AkihiroSuda/filegrain/version"
 )
 
 type fromRootFSBuilder struct {
@@ -120,7 +121,7 @@ func putContinuityManifestBlobs(img, source string, manifest *continuity.Manifes
 		return nil, err
 	}
 	return &spec.Descriptor{
-		MediaType: "application/vnd.continuity.manifest.v0+pb", // TODO: JSON
+		MediaType: continuityutil.MediaTypeManifestV0Protobuf, // TODO: JSON
 		Digest:    d,
 		Size:      int64(len(manifestBytes)),
 	}, nil

--- a/commands/build.go
+++ b/commands/build.go
@@ -3,8 +3,9 @@ package commands
 import (
 	"errors"
 
-	"github.com/AkihiroSuda/filegrain/builder"
 	"github.com/spf13/cobra"
+
+	"github.com/AkihiroSuda/filegrain/builder"
 )
 
 var (
@@ -18,7 +19,7 @@ var (
 		Short: "Build a FILEgrain image",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 2 {
-				errors.New("must specify source and target")
+				return errors.New("must specify source and target")
 			}
 			source, target := args[0], args[1]
 			b, err := builder.NewBuilderWithRootFS(source)

--- a/commands/main.go
+++ b/commands/main.go
@@ -1,17 +1,33 @@
 package commands
 
 import (
+	_ "crypto/sha256"
+	_ "crypto/sha512"
+
+	"github.com/Sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
 var (
+	mainCmdConfig struct {
+		debug bool
+	}
+
 	MainCmd = &cobra.Command{
 		Use:   "filegrain <command>",
 		Short: "FILEgrain: transport-agnostic, fine-grained content-addressable container image layout",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if mainCmdConfig.debug {
+				logrus.SetLevel(logrus.DebugLevel)
+				logrus.Debug("running in debug mode")
+			}
+			return nil
+		},
 	}
 )
 
 func init() {
+	MainCmd.PersistentFlags().BoolVar(&mainCmdConfig.debug, "debug", false, "debug")
 	MainCmd.AddCommand(MountCmd)
 	MainCmd.AddCommand(BuildCmd)
 }

--- a/commands/mount.go
+++ b/commands/mount.go
@@ -2,26 +2,87 @@ package commands
 
 import (
 	"errors"
+	"io/ioutil"
+	"os"
+	"os/signal"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/spf13/cobra"
 
 	"github.com/AkihiroSuda/filegrain/lazyfs"
-	"github.com/spf13/cobra"
+	"github.com/AkihiroSuda/filegrain/puller"
 )
 
-var MountCmd = &cobra.Command{
-	Use:   "mount <mountpoint> <manifest>",
-	Short: "Mount with lazy fs",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) != 2 {
-			return errors.New("must specify mountpoint and manifest")
-		}
-		opts := &lazyfs.ServerOptions{
-			Mountpoint: args[0],
-		}
-		sv, err := lazyfs.NewServer(opts)
-		if err != nil {
-			return err
-		}
-		sv.Serve()
-		return nil
-	},
+var (
+	mountCmdConfig struct {
+		debugFUSE bool
+		refName   string
+	}
+
+	MountCmd = &cobra.Command{
+		Use:   "mount <image> <mountpoint>",
+		Short: "Mount with lazy fs",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 2 {
+				return errors.New("must specify image and mountpoint")
+			}
+			img, mountpoint := args[0], args[1]
+			cachePath, err := ioutil.TempDir("", "filegrain-blobcache")
+			if err != nil {
+				return err
+			}
+			logrus.Infof("blob cache: %s", cachePath)
+			defer os.RemoveAll(cachePath) // FIXME
+			pvller, err := puller.NewBlobCacher(cachePath,
+				puller.NewLocalPuller())
+			if err != nil {
+				return err
+			}
+			opts := lazyfs.Options{
+				Mountpoint: mountpoint,
+				Puller:     pvller,
+				Image:      img,
+				RefName:    mountCmdConfig.refName,
+			}
+			return serve(opts)
+		},
+	}
+)
+
+func init() {
+	MountCmd.Flags().StringVar(&mountCmdConfig.refName, "tag", "latest", "tag (aka reference name)")
+	MountCmd.Flags().BoolVar(&mountCmdConfig.debugFUSE, "debug-fuse", false, "debug FUSE")
+}
+
+func serve(opts lazyfs.Options) error {
+	fs, err := lazyfs.NewFS(opts)
+	if err != nil {
+		return err
+	}
+	defer lazyfs.CleanupWithFS(fs)
+	sv, err := lazyfs.NewServer(fs)
+	if err != nil {
+		return err
+	}
+	if mountCmdConfig.debugFUSE {
+		fs.SetDebug(true)
+		sv.SetDebug(true)
+	}
+	go sv.Serve()
+	logrus.Infof("Mounting on %s", opts.Mountpoint)
+	sv.WaitMount()
+	logrus.Infof("Mounted on %s", opts.Mountpoint)
+	defer func() {
+		logrus.Infof("Unmounting %s", opts.Mountpoint)
+		sv.Unmount()
+		logrus.Infof("Unmounted %s", opts.Mountpoint)
+	}()
+	waitForSIGINT()
+	return nil
+}
+
+func waitForSIGINT() {
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+	<-c
 }

--- a/continuityutil/continuityutil.go
+++ b/continuityutil/continuityutil.go
@@ -1,0 +1,5 @@
+package continuityutil
+
+const (
+	MediaTypeManifestV0Protobuf = "application/vnd.continuity.manifest.v0+pb" // TODO: define in upstream continuity
+)

--- a/image/imageutil/imageutil.go
+++ b/image/imageutil/imageutil.go
@@ -3,8 +3,9 @@ package imageutil
 import (
 	"encoding/json"
 
-	"github.com/AkihiroSuda/filegrain/image"
 	spec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/AkihiroSuda/filegrain/image"
 )
 
 func WriteJSONBlob(img string, x interface{}, mediaType string) (*spec.Descriptor, error) {

--- a/lazyfs/dummycontent/dummycontent.go
+++ b/lazyfs/dummycontent/dummycontent.go
@@ -1,0 +1,118 @@
+package dummycontent
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+
+	"github.com/Sirupsen/logrus"
+	progressbar "github.com/cheggaaa/pb"
+	"github.com/opencontainers/go-digest"
+	"github.com/stevvooe/continuity"
+)
+
+type DummyRegularFileContent struct {
+	Size    int64
+	Digests []digest.Digest
+}
+
+// dummyRegularFile implements continuity.RegularFile
+type dummyRegularFile struct {
+	continuity.RegularFile
+	dummyContent       []byte
+	dummyContentDigest digest.Digest
+}
+
+func newDummyRegularfile(rf continuity.RegularFile) (*dummyRegularFile, error) {
+	dummyContent := DummyRegularFileContent{
+		Size:    rf.Size(),
+		Digests: rf.Digests(),
+	}
+	dummyContentB, err := json.Marshal(dummyContent)
+	if err != nil {
+		return nil, err
+	}
+	return &dummyRegularFile{
+		RegularFile:        rf,
+		dummyContent:       dummyContentB,
+		dummyContentDigest: digest.FromBytes(dummyContentB),
+	}, nil
+}
+
+func (rf *dummyRegularFile) Size() int64 {
+	return int64(len(rf.dummyContent))
+}
+
+func (rf *dummyRegularFile) Digests() []digest.Digest {
+	return []digest.Digest{rf.dummyContentDigest}
+}
+
+type dummyContinuity struct {
+	m        map[digest.Digest][]byte
+	manifest *continuity.Manifest
+}
+
+func newDummyContinuity(manifest *continuity.Manifest) (*dummyContinuity, error) {
+	dc := &dummyContinuity{
+		m:        make(map[digest.Digest][]byte, 0),
+		manifest: &continuity.Manifest{},
+	}
+	for _, r := range manifest.Resources {
+		if rf, ok := r.(continuity.RegularFile); ok {
+			dummyRF, err := newDummyRegularfile(rf)
+			if err != nil {
+				return nil, err
+			}
+			dc.m[dummyRF.dummyContentDigest] = dummyRF.dummyContent
+			r = dummyRF
+		}
+		dc.manifest.Resources = append(dc.manifest.Resources, r)
+	}
+	return dc, nil
+}
+
+// dummyContinuityContentProvider implements continuity.ContentProvider
+type dummyContinuityContentProvider struct {
+	continuity *dummyContinuity
+}
+
+func (cp *dummyContinuityContentProvider) Reader(d digest.Digest) (io.ReadCloser, error) {
+	b, ok := cp.continuity.m[d]
+	if !ok {
+		return nil, fmt.Errorf("not found: %s", d)
+	}
+	return ioutil.NopCloser(bytes.NewReader(b)), nil
+}
+
+func ApplyContinuityManifestWithDummyContents(dir string, manifest *continuity.Manifest) error {
+	dummyContinuity, err := newDummyContinuity(manifest)
+	if err != nil {
+		return err
+	}
+	provider := &dummyContinuityContentProvider{
+		continuity: dummyContinuity,
+	}
+	driver, err := continuity.NewSystemDriver()
+	if err != nil {
+		return err
+	}
+	ctx, err := continuity.NewContextWithOptions(dir,
+		continuity.ContextOptions{
+			Driver:   driver,
+			Provider: provider,
+		})
+	logrus.Infof("Converting continuity manifest (%d resources) to a file-based database under %s",
+		len(dummyContinuity.manifest.Resources), dir)
+	logrus.Infof("NOTE: this operation is slow because it creates a bunch of files, but could be mitigated by future memDB-based implementation. So this slowness does not hurt for POC!")
+	bar := progressbar.StartNew(len(dummyContinuity.manifest.Resources))
+	for _, resource := range dummyContinuity.manifest.Resources {
+		bar.Increment()
+		if err := ctx.Apply(resource); err != nil {
+			return err
+		}
+	}
+	bar.Finish()
+	return nil
+}

--- a/lazyfs/lazyfs.go
+++ b/lazyfs/lazyfs.go
@@ -1,46 +1,144 @@
 package lazyfs
 
 import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/Sirupsen/logrus"
 	"github.com/hanwen/go-fuse/fuse"
 	"github.com/hanwen/go-fuse/fuse/nodefs"
 	"github.com/hanwen/go-fuse/fuse/pathfs"
+
+	"github.com/AkihiroSuda/filegrain/lazyfs/dummycontent"
+	"github.com/AkihiroSuda/filegrain/puller"
 )
 
 // FS is a read-only filesystem with lazy-pull feature.
-// Supported digests:
-//  - SHA256
+//
+// FS implements github.com/hanwen/go-fuse/fuse/pathfs.FileSystem
 //
 // Supported objects:
 //  - regular files
 //  - symbolic links
 type FS struct {
 	pathfs.FileSystem
-	manifest interface{}
-	puller   interface{}
+	opts      Options
+	underlier string
+}
+
+func (fs *FS) openDummyContent(name string) (*dummycontent.DummyRegularFileContent, error) {
+	b, err := ioutil.ReadFile(filepath.Join(fs.underlier, name))
+	if err != nil {
+		return nil, err
+	}
+	var c dummycontent.DummyRegularFileContent
+	if err := json.Unmarshal(b, &c); err != nil {
+		return nil, err
+	}
+	if len(c.Digests) < 1 {
+		return nil, fmt.Errorf("expected len >= 1, got %d", len(c.Digests))
+	}
+	return &c, nil
 }
 
 func (fs *FS) GetAttr(name string, fc *fuse.Context) (*fuse.Attr, fuse.Status) {
-	return nil, fuse.ENOENT
+	attr, ok := fs.FileSystem.GetAttr(name, fc)
+	if ok != fuse.OK {
+		return attr, ok
+	}
+	c, _ := fs.openDummyContent(name)
+	if c != nil {
+		attr.Size = uint64(c.Size)
+	}
+	return attr, fuse.OK
 }
 
-func (fs *FS) OpenDir(name string, fc *fuse.Context) ([]fuse.DirEntry, fuse.Status) {
-	return nil, fuse.ENOENT
+func (fs *FS) Open(name string, flags uint32, fc *fuse.Context) (nodefs.File, fuse.Status) {
+	f, ok := fs.FileSystem.Open(name, flags, fc)
+	if ok != fuse.OK {
+		return f, ok
+	}
+	c, _ := fs.openDummyContent(name)
+	if c == nil {
+		return f, ok
+	}
+	reader, err := fs.opts.Puller.PullBlob(fs.opts.Image, c.Digests[0])
+	if err != nil {
+		return nil, fuse.EIO
+	}
+	newf, err := newFile(name, reader, fs)
+	if err != nil {
+		return nil, fuse.EIO
+	}
+	return newf, fuse.OK
 }
 
-func (fs *FS) Open(name string, flagsd uint32, fc *fuse.Context) (nodefs.File, fuse.Status) {
-	return nil, fuse.ENOENT
+type file struct {
+	nodefs.File
+	name string
+	fs   *FS
 }
 
-type ServerOptions struct {
+func (f *file) GetAttr(out *fuse.Attr) fuse.Status {
+	attr, ok := f.fs.GetAttr(f.name, nil)
+	if attr != nil {
+		*out = *attr
+	}
+	return ok
+}
+
+func newFile(name string, reader io.Reader, fs *FS) (*file, error) {
+	b, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+	f := nodefs.NewReadOnlyFile(nodefs.NewDataFile(b))
+	return &file{
+		File: f,
+		name: name,
+		fs:   fs,
+	}, nil
+}
+
+type Options struct {
 	Mountpoint string
+	Puller     puller.Puller
+	Image      string
+	RefName    string
 }
 
-func NewServer(opts *ServerOptions) (*fuse.Server, error) {
-	fs := &FS{FileSystem: pathfs.NewDefaultFileSystem()}
-	nfs := pathfs.NewPathNodeFs(fs, nil)
+func NewFS(opts Options) (*FS, error) {
+	underlier, err := ioutil.TempDir("", "filegrain-underlier")
+	if err != nil {
+		return nil, err
+	}
+	logrus.Infof("underlier: %s", underlier)
+	if err := loadUnderlier(opts, underlier); err != nil {
+		return nil, err
+	}
+	fs := &FS{
+		FileSystem: pathfs.NewReadonlyFileSystem(pathfs.NewLoopbackFileSystem(underlier)),
+		opts:       opts,
+		underlier:  underlier,
+	}
+	return fs, nil
+}
+
+func CleanupWithFS(fs *FS) {
+	logrus.Infof("removing %s", fs.underlier)
+	os.RemoveAll(fs.underlier)
+}
+
+func NewServer(fs *FS) (*fuse.Server, error) {
+	nfs := pathfs.NewPathNodeFs(pathfs.NewReadonlyFileSystem(fs), nil)
 	conn := nodefs.NewFileSystemConnector(nfs.Root(), nil)
-	return fuse.NewServer(conn.RawFS(), opts.Mountpoint,
+	return fuse.NewServer(conn.RawFS(), fs.opts.Mountpoint,
 		&fuse.MountOptions{
-			AllowOther: true,
+			FsName: fs.opts.Mountpoint + ":" + fs.opts.RefName,
+			Name:   "filegrain.lazyfs",
 		})
 }

--- a/lazyfs/resource.go
+++ b/lazyfs/resource.go
@@ -1,0 +1,82 @@
+package lazyfs
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+
+	spec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stevvooe/continuity"
+
+	"github.com/AkihiroSuda/filegrain/continuityutil"
+	"github.com/AkihiroSuda/filegrain/image"
+	"github.com/AkihiroSuda/filegrain/lazyfs/dummycontent"
+)
+
+func loadContinuityManifest(opts Options, desc *spec.Descriptor) (*continuity.Manifest, error) {
+	manifestBlob, err := loadBlobWithDescriptor(opts, desc)
+	if err != nil {
+		return nil, err
+	}
+	manifest, err := continuity.Unmarshal(manifestBlob)
+	if err != nil {
+		return nil, err
+	}
+	return manifest, nil
+}
+
+func loadImageManifest(opts Options) (*spec.Manifest, error) {
+	idx, err := opts.Puller.PullIndex(opts.Image)
+	if err != nil {
+		return nil, err
+	}
+	var imageManifestDesc *spec.Descriptor
+	for _, m := range idx.Manifests {
+		mRefName, ok := m.Annotations[image.RefNameAnnotation]
+		if ok && mRefName == opts.RefName {
+			imageManifestDesc = &m
+			break
+		}
+	}
+	if imageManifestDesc == nil {
+		return nil, fmt.Errorf("unknown reference name: %q", opts.RefName)
+	}
+	imageManifestBlob, err := loadBlobWithDescriptor(opts, imageManifestDesc)
+	if err != nil {
+		return nil, err
+	}
+	var imageManifest spec.Manifest
+	if err := json.Unmarshal(imageManifestBlob, &imageManifest); err != nil {
+		return nil, err
+	}
+	return &imageManifest, nil
+}
+
+func loadBlobWithDescriptor(opts Options, desc *spec.Descriptor) ([]byte, error) {
+	r, err := opts.Puller.PullBlob(opts.Image, desc.Digest)
+	if err != nil {
+		return nil, err
+	}
+	return ioutil.ReadAll(r)
+}
+
+func loadUnderlier(opts Options, dir string) error {
+	imageManifest, err := loadImageManifest(opts)
+	if err != nil {
+		return err
+	}
+	for _, layer := range imageManifest.Layers {
+		// TODO: support mixing up tar layers and continutiy layers..
+		if layer.MediaType != continuityutil.MediaTypeManifestV0Protobuf {
+			return fmt.Errorf("unsupported layer mediaType: %s", layer.MediaType)
+		}
+		manifest, err := loadContinuityManifest(opts, &layer)
+		if err != nil {
+			return err
+		}
+		if err := dummycontent.ApplyContinuityManifestWithDummyContents(dir, manifest); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/puller/cacher.go
+++ b/puller/cacher.go
@@ -1,0 +1,116 @@
+package puller
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"sync/atomic"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/opencontainers/go-digest"
+	spec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/AkihiroSuda/filegrain/image"
+)
+
+type pullStatus int
+
+const (
+	pullStatusUnknown pullStatus = iota
+	pullStatusPulling
+	pullStatusPulled
+)
+
+type BlobCacher struct {
+	cachePath string
+	puller    Puller
+
+	pullStatus     map[digest.Digest]pullStatus
+	pullStatusCond *sync.Cond
+
+	pulledBlobBytes uint64 // atomic
+}
+
+func NewBlobCacher(cachePath string, puller Puller) (*BlobCacher, error) {
+	if _, err := os.Stat(cachePath); err != nil {
+		return nil, err
+	}
+	cacher := &BlobCacher{
+		cachePath:       cachePath,
+		puller:          puller,
+		pullStatus:      make(map[digest.Digest]pullStatus, 0),
+		pullStatusCond:  sync.NewCond(&sync.Mutex{}),
+		pulledBlobBytes: 0,
+	}
+	// TODO: load cacher.pulled
+	return cacher, nil
+}
+
+func (p *BlobCacher) PullBlob(img string, d digest.Digest) (image.BlobReader, error) {
+	if err := p.cacheBlobIfNotYet(img, d); err != nil {
+		return nil, err
+	}
+	return p.openCachedBlob(img, d)
+}
+
+func (p *BlobCacher) cacheBlobIfNotYet(img string, d digest.Digest) error {
+	alreadyCached := false
+	for {
+		p.pullStatusCond.L.Lock()
+		st, ok := p.pullStatus[d]
+		if ok && st == pullStatusPulling {
+			p.pullStatusCond.Wait()
+			p.pullStatusCond.L.Unlock()
+		} else {
+			p.pullStatusCond.L.Unlock()
+			alreadyCached = st == pullStatusPulled
+			break
+		}
+	}
+	if !alreadyCached {
+		return p.cacheBlob(img, d)
+	}
+	return nil
+}
+
+func (p *BlobCacher) cacheBlob(img string, d digest.Digest) error {
+	// TODO: use hardlink when possible?
+	logrus.Debugf("caching blob: %s", d)
+	p.pullStatusCond.L.Lock()
+	p.pullStatus[d] = pullStatusPulling
+	p.pullStatusCond.L.Unlock()
+	r, err := p.puller.PullBlob(img, d)
+	if err != nil {
+		return err
+	}
+	w, err := image.NewBlobWriter(p.cachePath, d.Algorithm())
+	if err != nil {
+		return err
+	}
+	copied, err := io.Copy(w, r)
+	if err != nil {
+		return err
+	}
+	if err := w.Close(); err != nil {
+		return err
+	}
+	if dd := w.Digest(); dd == nil || *dd != d {
+		return fmt.Errorf("expected %q, got %q", d, dd)
+	}
+	totalCopied := atomic.AddUint64(&p.pulledBlobBytes, uint64(copied))
+	logrus.Infof("Total blob bytes pulled in this session: %d B", totalCopied)
+	p.pullStatusCond.L.Lock()
+	p.pullStatus[d] = pullStatusPulled
+	p.pullStatusCond.L.Unlock()
+	p.pullStatusCond.Broadcast()
+	return nil
+}
+
+func (p *BlobCacher) openCachedBlob(img string, d digest.Digest) (image.BlobReader, error) {
+	return image.GetBlobReader(p.cachePath, d)
+}
+
+func (p *BlobCacher) PullIndex(img string) (*spec.Index, error) {
+	return p.puller.PullIndex(img)
+}

--- a/puller/local.go
+++ b/puller/local.go
@@ -1,0 +1,24 @@
+package puller
+
+import (
+	"github.com/opencontainers/go-digest"
+	spec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/AkihiroSuda/filegrain/image"
+)
+
+// LocalPuller lacks caching. Use with BlobCacher.
+type LocalPuller struct {
+}
+
+func NewLocalPuller() *LocalPuller {
+	return &LocalPuller{}
+}
+
+func (p *LocalPuller) PullBlob(img string, d digest.Digest) (image.BlobReader, error) {
+	return image.GetBlobReader(img, d)
+}
+
+func (p *LocalPuller) PullIndex(img string) (*spec.Index, error) {
+	return image.ReadIndex(img)
+}

--- a/puller/puller.go
+++ b/puller/puller.go
@@ -1,0 +1,13 @@
+package puller
+
+import (
+	"github.com/opencontainers/go-digest"
+	spec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/AkihiroSuda/filegrain/image"
+)
+
+type Puller interface {
+	PullBlob(img string, d digest.Digest) (image.BlobReader, error)
+	PullIndex(img string) (*spec.Index, error)
+}


### PR DESCRIPTION
- no remote image yet, only supports local image
- `underlier` DB slow, because it creates a bunch of files; needs to be
refined, but does not hurt for POC

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>